### PR TITLE
Fix: Create a local batch events variable only once instead for every…

### DIFF
--- a/kong-plugin-moesif-0.2.14-1.rockspec
+++ b/kong-plugin-moesif-0.2.14-1.rockspec
@@ -1,7 +1,7 @@
 package = "kong-plugin-moesif"  -- TODO: rename, must match the info in the filename of this rockspec!
                                   -- as a convention; stick to the prefix: `kong-plugin-`
-version = "0.2.13-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
--- The version '0.2.13' is the source code version, the trailing '1' is the version of this rockspec.
+version = "0.2.14-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
+-- The version '0.2.14' is the source code version, the trailing '1' is the version of this rockspec.
 -- whenever the source version changes, the rockspec should be reset to 1. The rockspec version is only
 -- updated (incremented) when this file changes, but the source remains the same.
 
@@ -12,7 +12,7 @@ local pluginName = package:match("^kong%-plugin%-(.+)$")  -- "moesif"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Moesif/kong-plugin-moesif/",
-  tag = "0.2.13"
+  tag = "0.2.14"
 }
 
 description = {

--- a/kong/plugins/moesif/handler.lua
+++ b/kong/plugins/moesif/handler.lua
@@ -93,7 +93,7 @@ function MoesifLogHandler:init_worker()
 end
 
 MoesifLogHandler.PRIORITY = 5
-MoesifLogHandler.VERSION = "0.2.13"
+MoesifLogHandler.VERSION = "0.2.14"
 
 -- Plugin version
 plugin_version = MoesifLogHandler.VERSION


### PR DESCRIPTION
… queue

Fix: Create a local batch events variable only once instead for every queue
Fix: Remove redundant code while creating table
Add: Manually garbage collect every 4 seconds
Add: Manually close socket connection after failing to keep socket alive
Add: Debug message to track # of incoming request and # of event send to Moesif
Bump version to 0.2.14