### PR TITLE
perf optimizations for higher RPM environments

### DIFF
--- a/kong-plugin-moesif-0.2.15-1.rockspec
+++ b/kong-plugin-moesif-0.2.15-1.rockspec
@@ -1,7 +1,7 @@
 package = "kong-plugin-moesif"  -- TODO: rename, must match the info in the filename of this rockspec!
                                   -- as a convention; stick to the prefix: `kong-plugin-`
-version = "0.2.14-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
--- The version '0.2.14' is the source code version, the trailing '1' is the version of this rockspec.
+version = "0.2.15-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
+-- The version '0.2.15' is the source code version, the trailing '1' is the version of this rockspec.
 -- whenever the source version changes, the rockspec should be reset to 1. The rockspec version is only
 -- updated (incremented) when this file changes, but the source remains the same.
 
@@ -12,7 +12,7 @@ local pluginName = package:match("^kong%-plugin%-(.+)$")  -- "moesif"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Moesif/kong-plugin-moesif/",
-  tag = "0.2.14"
+  tag = "0.2.15"
 }
 
 description = {

--- a/kong/plugins/moesif/connection.lua
+++ b/kong/plugins/moesif/connection.lua
@@ -3,6 +3,8 @@ local helper = require "kong.plugins.moesif.helpers"
 local HTTPS = "https"
 local ngx_log = ngx.log
 local ngx_log_ERR = ngx.ERR
+local session 
+local sessionerr
 
 -- Create new connection
 -- @param `url_path`  api endpoint
@@ -31,10 +33,15 @@ function _M.get_connection(url_path, conf)
   end
 
   if parsed_url.scheme == HTTPS then
-    local _, err = sock:sslhandshake(true, host, false)
-    if err then
+    if session ~= nil then 
+      session, sessionerr = sock:sslhandshake(session, host, false)
+    else 
+      session, sessionerr = sock:sslhandshake(true, host, false)
+    end
+
+    if sessionerr then
       if conf.debug then 
-        ngx_log(ngx_log_ERR, "[moesif] failed to do SSL handshake with " .. host .. ":" .. tostring(port) .. ": ", err)
+        ngx_log(ngx_log_ERR, "[moesif] failed to do SSL handshake with " .. host .. ":" .. tostring(port) .. ": ", sessionerr)
       end
     end
   end

--- a/kong/plugins/moesif/handler.lua
+++ b/kong/plugins/moesif/handler.lua
@@ -93,7 +93,7 @@ function MoesifLogHandler:init_worker()
 end
 
 MoesifLogHandler.PRIORITY = 5
-MoesifLogHandler.VERSION = "0.2.14"
+MoesifLogHandler.VERSION = "0.2.15"
 
 -- Plugin version
 plugin_version = MoesifLogHandler.VERSION

--- a/kong/plugins/moesif/schema.lua
+++ b/kong/plugins/moesif/schema.lua
@@ -13,7 +13,7 @@ return {
     response_masks = {default = {}, type = "array"},
     response_body_masks = {default = {}, type = "array"},
     response_header_masks = {default = {}, type = "array"},
-    batch_size = {default = 25, type = "number"},
+    batch_size = {default = 200, type = "number"},
     disable_transaction_id = {default = false, type = "boolean"},
     debug = {default = false, type = "boolean"},
     user_id_header = {default = "", type = "string"},


### PR DESCRIPTION
Remove: Reading response after sending events
Refactor: Schedule job to fetch app config every 60 second
Refactor: Manually collect garbage every 8 cycle
Refactor: Reuse socket sesion while doing handshake
Refactor: Change default batch size to 200
Refactor: Add debug logs to measure the time took to connect, send event
Bump version to 0.2.15