### PR TITLE
#187449956 Refactor: Use kong.request getMethod instead of ngx.req getMethod

### DIFF
--- a/kong-plugin-moesif-2.0.12-1.rockspec
+++ b/kong-plugin-moesif-2.0.12-1.rockspec
@@ -1,7 +1,7 @@
 package = "kong-plugin-moesif"  -- TODO: rename, must match the info in the filename of this rockspec!
                                 -- as a convention; stick to the prefix: `kong-plugin-`
-version = "2.0.11-1"        -- TODO: renumber, must match the info in the filename of this rockspec!
--- The version '2.0.11' is the source code version, the trailing '1' is the version of this rockspec.
+version = "2.0.12-1"        -- TODO: renumber, must match the info in the filename of this rockspec!
+-- The version '2.0.12' is the source code version, the trailing '1' is the version of this rockspec.
 -- whenever the source version changes, the rockspec should be reset to 1. The rockspec version is only
 -- updated (incremented) when this file changes, but the source remains the same.
 
@@ -12,7 +12,7 @@ local pluginName = package:match("^kong%-plugin%-(.+)$")  -- "moesif"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Moesif/kong-plugin-moesif/",
-  tag = "2.0.11"
+  tag = "2.0.12"
 }
 
 description = {

--- a/kong/plugins/moesif/handler.lua
+++ b/kong/plugins/moesif/handler.lua
@@ -1,7 +1,7 @@
 local serializer = require "kong.plugins.moesif.moesif_ser"
 local governance = require "kong.plugins.moesif.moesif_gov"
 local MoesifLogHandler = {
-  VERSION  = "2.0.11",
+  VERSION  = "2.0.12",
   PRIORITY = 5,
 }
 local log = require "kong.plugins.moesif.log"

--- a/kong/plugins/moesif/moesif_gov.lua
+++ b/kong/plugins/moesif/moesif_gov.lua
@@ -1,5 +1,5 @@
 local _M = {}
-local req_get_method = ngx.req.get_method
+local req_get_method = kong.request.get_method
 local ngx_log = ngx.log
 local helper = require "kong.plugins.moesif.helpers"
 local regex_config_helper = require "kong.plugins.moesif.regex_config_helpers"

--- a/kong/plugins/moesif/moesif_ser.lua
+++ b/kong/plugins/moesif/moesif_ser.lua
@@ -1,5 +1,5 @@
 local ngx_now = ngx.now
-local req_get_method = ngx.req.get_method
+local req_get_method = kong.request.get_method
 local req_start_time = ngx.req.start_time
 local req_get_headers = ngx.req.get_headers
 local res_get_headers = ngx.resp and ngx.resp.get_headers or nil


### PR DESCRIPTION
Refactor: Use kong.request getMethod instead of ngx.req getMethod 
Bump version to 2.0.12